### PR TITLE
Fixed loading bug when creating project presentation

### DIFF
--- a/components/Project/ProjectPresentation/Form/ProjectPresentationForm.container.js
+++ b/components/Project/ProjectPresentation/Form/ProjectPresentationForm.container.js
@@ -87,9 +87,9 @@ const ProjectPresentationFormContainer = ({
       } catch (err) {
         logger.error(err);
         onError('Error Saving Project Presentation');
+        doLoad(false);
       }
     }
-    doLoad(false);
   };
 
   return isTriggeredAction ? (


### PR DESCRIPTION
- Save button was enabling before page redirected to the created project presentation, this allowed to click mutliple times the save button creating multiple identical presentations.
- now the button is only re-enabled when it fails to create the presentation   